### PR TITLE
chore: update CI user for integration with trestlebot action

### DIFF
--- a/.github/workflows/autofix-cd.yml
+++ b/.github/workflows/autofix-cd.yml
@@ -11,13 +11,19 @@ jobs:
   auto-update:
     name: Autofix compdef content
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Clone
         uses: actions/checkout@v3
         with:
           ref:  ${{ github.head_ref }}
+      - name: Generate app token
+        uses: tibdex/github-app-token@v1
+        id: get_installation_token
+        with: 
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+          permissions: >-
+            {"contents": "write"}
       - name: Run trestlebot
         id: autofix-cd
         uses: RedHatProductSecurity/trestle-bot@main
@@ -27,4 +33,4 @@ jobs:
           branch: ${{ github.head_ref }}
           file_pattern: "*.json,markdown/*"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_installation_token.outputs.token }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,7 @@
 name: Evaluate component definitions
 on:
   pull_request:
-    types: [ opened, review_requested, ready_for_review, reopened, synchronize ]
+    types: [ opened, ready_for_review, reopened, synchronize ]
     branches:
       - main
     paths:
@@ -26,14 +26,10 @@ jobs:
           markdown_path: "markdown/components"
           oscal_model: "compdef"
           check_only: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: CSV sanity check 
         run: make check-csv
   
   call-assemble:
     needs: [test]
-    permissions:
-      contents: write
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/autofix-cd.yml


### PR DESCRIPTION
Update the access token used with trestle-bot Action to workaround [limitations ](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)with the generated GITHUB_TOKEN. 