### PR TITLE
build(deps): bump trestlebot version to 0.4.2

### DIFF
--- a/.github/workflows/autofix-cd.yml
+++ b/.github/workflows/autofix-cd.yml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Autofix components
         id: autofix-component
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.3.0
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.4.2
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"

--- a/.github/workflows/create-new.yml
+++ b/.github/workflows/create-new.yml
@@ -38,7 +38,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Create new component definition
         id: create-cd
-        uses: RedHatProductSecurity/trestle-bot/actions/create-cd@v0.4.1
+        uses: RedHatProductSecurity/trestle-bot/actions/create-cd@v0.4.2
         with:
           markdown_path: "markdown/components"
           profile_name: ${{ github.event.inputs.import_name }}

--- a/.github/workflows/regenerate-cd.yml
+++ b/.github/workflows/regenerate-cd.yml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Regenerate component definitions
         id: regenerate
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.3.0
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.4.2
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"

--- a/.github/workflows/transform-rules.yml
+++ b/.github/workflows/transform-rules.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Transform rules
         id: transform
-        uses: RedHatProductSecurity/trestle-bot/actions/rules-transform@v0.4.1
+        uses: RedHatProductSecurity/trestle-bot/actions/rules-transform@v0.4.2
         with:
           file_pattern: "*.json,rules/*"
           branch: ${{ inputs.branch }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Check components
         id: check-components
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.3.0
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.4.2
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"


### PR DESCRIPTION
Update trestlebot action used in workflows to latest version

Test on my fork - https://github.com/jpower432/oscal-component-definitions/pull/13/commits