### PR TITLE
refactor: trestle-bot migration from check_only

### DIFF
--- a/.github/workflows/autofix-cd.yml
+++ b/.github/workflows/autofix-cd.yml
@@ -33,7 +33,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Autofix components
         id: autofix-component
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.1
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"

--- a/.github/workflows/create-new.yml
+++ b/.github/workflows/create-new.yml
@@ -38,7 +38,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Create new component definition
         id: create-cd
-        uses: RedHatProductSecurity/trestle-bot/actions/create-cd@v0.8.1
+        uses: RedHatProductSecurity/trestle-bot/actions/create-cd@v0.9.0
         with:
           markdown_path: "markdown/components"
           profile_name: ${{ github.event.inputs.import_name }}

--- a/.github/workflows/transform-rules.yml
+++ b/.github/workflows/transform-rules.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Transform rules
         id: transform
-        uses: RedHatProductSecurity/trestle-bot/actions/rules-transform@v0.8.1
+        uses: RedHatProductSecurity/trestle-bot/actions/rules-transform@v0.9.0
         with:
           file_pattern: "*.json,rules/*"
           branch: ${{ inputs.branch }}
@@ -40,7 +40,7 @@ jobs:
           commit_user_name: "trestle-bot[bot]"
           commit_user_email: "136850459+trestle-bot[bot]@users.noreply.github.com"
       - name: Regenerate component definitions
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.1
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"

--- a/.github/workflows/update-profiles.yml
+++ b/.github/workflows/update-profiles.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ steps.get_installation_token.outputs.token }}
       - name: Update from upstream repo
         id: sync_upstreams
-        uses: RedHatProductSecurity/trestle-bot/actions/sync-upstreams@v0.8.1
+        uses: RedHatProductSecurity/trestle-bot/actions/sync-upstreams@v0.9.0
         with:
           branch: "sync-upstream-${{ github.run_id }}"
           target_branch: "main"
@@ -40,7 +40,7 @@ jobs:
             https://github.com/RedHatProductSecurity/oscal-profiles@${{ github.event.inputs.ref }}
       - name: Regenerate component definitions
         if: ${{ steps.sync_upstreams.outputs.commit }}
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.1
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Check components
         id: check-components
-        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.8.1
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,12 +21,18 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
       - name: Check components
-        id: check-components
+        id: check
         uses: RedHatProductSecurity/trestle-bot/actions/autosync@v0.9.0
         with:
           markdown_path: "markdown/components"
           oscal_model: "compdef"
-          check_only: true
+          dry_run: true
+      - name: Fail
+        if: ${{ steps.check.outputs.changes == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+              core.setFailed('Changes detected. Manual intervention may be required.')
 
   # Only autofix if the test job fails and the PR is from the same repo
   call-autofix:

--- a/component-definitions/example/component-definition.json
+++ b/component-definitions/example/component-definition.json
@@ -1,15 +1,15 @@
 {
   "component-definition": {
-    "uuid": "3172756f-df6b-4f45-bb91-83c228963c1a",
+    "uuid": "4bc731f1-03bf-4f56-a76a-d8ea62dfd788",
     "metadata": {
       "title": "Component definition for example",
-      "last-modified": "2024-03-15T00:07:34.346682+00:00",
+      "last-modified": "2024-05-02T15:23:25+00:00",
       "version": "1.0",
       "oscal-version": "1.0.4"
     },
     "components": [
       {
-        "uuid": "7b595bb9-c6ec-409c-b109-95e71ddf2f56",
+        "uuid": "b8c06a65-a8f5-424b-89de-d81fb36b1902",
         "type": "service",
         "title": "Example",
         "description": "Example Application",
@@ -41,13 +41,13 @@
           {
             "name": "Parameter_Value_Alternatives",
             "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
-            "value": "{'default': '5%', '5pc': '5%', '10pc': '10%', '15pc': '15%', '20pc': '20%'}",
+            "value": "{\"default\": \"5%\", \"5pc\": \"5%\", \"10pc\": \"10%\", \"15pc\": \"15%\", \"20pc\": \"20%\"}",
             "remarks": "rule_set_0"
           }
         ],
         "control-implementations": [
           {
-            "uuid": "21db09e0-ce6f-4e67-9116-b2358a2f4074",
+            "uuid": "8f6f79aa-101e-4cd3-a7bb-5d6a4a80fa1f",
             "source": "profiles/fedramp_rev5_high/profile.json",
             "description": "FedRAMP REV5 High Baseline",
             "set-parameters": [
@@ -60,7 +60,7 @@
             ],
             "implemented-requirements": [
               {
-                "uuid": "fac395f0-1a36-4c97-b7c4-805c08051a81",
+                "uuid": "54158878-afd7-49bb-ad08-8a6004adb5e2",
                 "control-id": "ac-1",
                 "description": "",
                 "props": [
@@ -68,10 +68,6 @@
                     "name": "Rule_Id",
                     "ns": "https://oscal-compass.github.io/compliance-trestle/schemas/oscal",
                     "value": "Test-rule_001"
-                  },
-                  {
-                    "name": "implementation-status",
-                    "value": "planned"
                   }
                 ]
               }


### PR DESCRIPTION
Updates GitHub Actions workflow for breaking changes in trestle-bot v0.9.0.

Testing completed in fork [here](https://github.com/jpower432/oscal-component-definitions/pull/15).